### PR TITLE
Distinguish between variable declaration and variable usage.

### DIFF
--- a/LESS.tmLanguage
+++ b/LESS.tmLanguage
@@ -357,12 +357,6 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>@[a-zA-Z0-9_-][\w-]*</string>
-			<key>name</key>
-			<string>variable.other.less</string>
-		</dict>
-		<dict>
-			<key>match</key>
 			<string>(?>@[a-zA-Z0-9_-][\w-]*+)(?!:)</string>
 			<key>name</key>
 			<string>variable.other.less</string>
@@ -372,6 +366,12 @@
 			<string>@[a-zA-Z0-9_-][\w-]*</string>
 			<key>name</key>
 			<string>variable.declaration.less</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\!important|$|%|&amp;|\*|\-\-|\-|\+\+|\+|~|===|==|=|!=|!==|&lt;=|&gt;=|&lt;&lt;=|&gt;&gt;=|&gt;&gt;&gt;=|&lt;&gt;|&lt;|&gt;|!|&amp;&amp;|\|\||\?\:|\*=|(?&lt;!\()/=|%=|\+=|\-=|&amp;=|\^=|\/|and|when\b</string>
+			<key>name</key>
+			<string>keyword.operator.less</string>
 		</dict>
 		<dict>
 			<key>match</key>


### PR DESCRIPTION
I'm proposing to allow for different highlighting for variable declarations and variable usage.  
In a stylesheet, when a variable is used, I like to set its color to something quite noticeable (I use orange), but this becomes quite hard on the eyes in LESS files that are used to make a lot of variable declarations. 

So, I changed `variable.other.less` to exclude variable declarations (the existing pattern, but excluding strings ending in `:`), and created a new pattern for `variable.declaration.less`.
