### PR TITLE
Style extend()

### DIFF
--- a/LESS.tmLanguage
+++ b/LESS.tmLanguage
@@ -328,7 +328,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>([%a-zA-Z\-\_\d]*)(?=\()</string>
+					<string>(([%a-zA-Z\-\_\d]*)|(\:extend))(?=\()</string>
 					<key>name</key>
 					<string>support.function.less</string>
 				</dict>

--- a/tests.less
+++ b/tests.less
@@ -271,6 +271,16 @@ body {
 .mixin .sub-mixin(@param);
 
 // --------------------------------------------------
+// Extensions
+
+.extend:extend(.extension, .extension all, .extension any) { }
+.extend {
+  &:extend([data="attr"], .extension any, .extension all, .selector@{name});
+}
+.extend:extend(.extension) { // inline comment
+}
+
+// --------------------------------------------------
 // Operations
 
 @base: 5%;


### PR DESCRIPTION
- fixes inline comments after extended selectors
