### PR TITLE
Adding better support for .class and #id allowed chars.

### DIFF
--- a/LESS.tmLanguage
+++ b/LESS.tmLanguage
@@ -748,7 +748,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(\.)[a-zA-Z0-9_-]+</string>
+					<string>(\.)[a-zA-Z_][a-zA-Z0-9_-]*</string>
 					<key>name</key>
 					<string>entity.other.attribute-name.class.css</string>
 				</dict>
@@ -762,7 +762,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(#)[a-zA-Z][a-zA-Z0-9_-]*</string>
+					<string>(#)[a-zA-Z_][a-zA-Z0-9_-]*</string>
 					<key>name</key>
 					<string>entity.other.attribute-name.id.css</string>
 				</dict>

--- a/LESS.tmLanguage.json
+++ b/LESS.tmLanguage.json
@@ -144,7 +144,7 @@
           "name" : "entity.name.tag.css, keyword.control.html.elements"
         },
         {
-          "match" : "(\\.)[a-zA-Z0-9_-]+",
+          "match" : "(\\.)[a-zA-Z_][a-zA-Z0-9_-]*",
           "captures" : {
             "1" : {
               "name" : "punctuation.definition.entity.css"
@@ -153,7 +153,7 @@
           "name" : "entity.other.attribute-name.class.css"
         },
         {
-          "match" : "(#)[a-zA-Z][a-zA-Z0-9_-]*",
+          "match" : "(#)[a-zA-Z_][a-zA-Z0-9_-]*",
           "captures" : {
             "1" : {
               "name" : "punctuation.definition.entity.css"


### PR DESCRIPTION
I noticed that #_ does not highlight as an identifier. According to the specs underscore is allowed directly after # and the same rules apply to .class so I changed the regex for that as well to be the same as for #id. 

http://www.w3.org/TR/CSS2/syndata.html#value-def-identifier

Cases I did not cover in this change are
- allow single hyphen 
- allow single hyphen followed by a digit
