### PR TITLE
Fix file extension

### DIFF
--- a/LESS.tmLanguage
+++ b/LESS.tmLanguage
@@ -7,7 +7,7 @@
 	<key>fileTypes</key>
 	<array>
 		<string>less</string>
-		<string>css</string>
+		<string>css.less</string>
 	</array>
 	<key>foldingStartMarker</key>
 	<string>/\*\*(?!\*)|\{\s*($|/\*(?!.*?\*/.*\S))</string>


### PR DESCRIPTION
*.css should be opened with `Default CSS` syntax by default if `LESS` installed. Users can change this behavior via `View -> Syntax -> Open all with current extension as ...`