### PR TITLE
Adding vmax, fr units to syntax definition

### DIFF
--- a/LESS.sublime-syntax
+++ b/LESS.sublime-syntax
@@ -323,7 +323,7 @@ contexts:
       scope: constant.other.color.rgb-value.css
       captures:
         1: punctuation.definition.constant.css
-    - match: '(?x)(?:-|\+)?(?:(?:[0-9]+(?:\.[0-9]+)?)|(?:\.[0-9]+))((?:vw|vmin|vh|turn|s|rem|rad|px|pt|pc|ms|mm|in|grad|ex|em|dppx|dpi|dpcm|deg|cm|ch)\b|%)?'
+    - match: '(?x)(?:-|\+)?(?:(?:[0-9]+(?:\.[0-9]+)?)|(?:\.[0-9]+))((?:vw|vmin|vmax|vh|turn|s|rem|rad|px|pt|pc|ms|mm|in|grad|fr|ex|em|dppx|dpi|dpcm|deg|cm|ch)\b|%)?'
       scope: constant.numeric.css
       captures:
         1: keyword.other.unit.css


### PR DESCRIPTION
Hey there!

I was doing some CSS grid work and noticed the fractional unit `fr` was not being highlighted, so I added it. You can learn more about the `fr` unit on MDN [here](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout#The_fr_Unit).

I also noticed `vmax` units were not in the syntax definition even though `vmin` is, so I added that as well. Here's the [MDN article about viewport units](https://developer.mozilla.org/en-US/docs/Web/CSS/length#Viewport-percentage_lengths).